### PR TITLE
Handle record types 02, 03 and 05

### DIFF
--- a/hexfile/core.py
+++ b/hexfile/core.py
@@ -3,9 +3,15 @@ import itertools
 def short(msb,lsb):
     return (msb<<8) | lsb
 
+def long(b1, b2, b3, b4):
+    return (b1<<24) | (b2<<16) | (b3<<8) | b4
+
 class HexFile(object):
-    def __init__(self, segments):
+    def __init__(self, segments, eip, cs, ip):
         self.segments = segments
+        self.eip = eip
+        self.cs = cs
+        self.ip = ip
 
     def __getitem__(self, val):
         if isinstance(val, slice):
@@ -31,12 +37,16 @@ class HexFile(object):
 
     @staticmethod
     def load(filename):
-        segments = [Segment(0)]
+        segments = []
+        eip = None
+        cs = None
+        ip = None
 
         with open(filename) as fp:
             lines = fp.readlines()
 
         extended_linear_address = 0
+        extended_segment_address = 0
         current_address = 0
         end_of_file = False
 
@@ -63,7 +73,7 @@ class HexFile(object):
 
             if record_type == 0:
                 if byte_count == len(data):
-                    current_address = (address | extended_linear_address)
+                    current_address = (address + extended_linear_address + extended_segment_address) & 0xffffffff
                     have_segment = False
                     for segment in segments:
                         if segment.end_address == current_address:
@@ -76,14 +86,26 @@ class HexFile(object):
                     raise Exception("Data record reported size does not match actual size on line %d" % lineno)
             elif record_type == 1:
                 end_of_file = True
+            elif record_type == 2:
+                if byte_count != 2 or len(data) != 2:
+                    raise Exception("Byte count misreported in extended segment address record on line %d" % lineno)
+                extended_segment_address = short(*data) << 4
+            elif record_type == 3:
+                if byte_count != 4 or len(data) != 4:
+                    raise Exception("Byte count misreported in start segment address record on line %d" % lineno)
+                cs = short(*data[0:2])
+                ip = short(*data[2:4])
             elif record_type == 4:
                 if byte_count != 2 or len(data) != 2:
                     raise Exception("Byte count misreported in extended linear address record on line %d" % lineno)
                 extended_linear_address = short(*data) << 16
-
+            elif record_type == 5:
+                if byte_count != 4 or len(data) != 4:
+                    raise Exception("Byte count misreported in start linear address record on line %d" % lineno)
+                eip = long(*data)
             else:
-                raise Exception("Unknown record type: %s" % record_type) 
-        return HexFile(segments)
+                raise Exception("Unknown record type: %s" % record_type)
+        return HexFile(segments, eip, cs, ip)
 
     def pretty_string(self, stride=16):
         retval = []
@@ -91,6 +113,12 @@ class HexFile(object):
             retval.append('Segment @ 0x%08x (%d bytes)' % (segment.start_address, segment.size))
             retval.append(segment.pretty_string(stride=stride))
             retval.append('')
+        if self.eip is not None:
+            retval.append('EIP 0x%x' % self.eip)
+        if self.cs is not None:
+            retval.append('CS 0x%x' % self.cs)
+        if self.ip is not None:
+            retval.append('IP 0x%x' % self.ip)
         return '\n'.join(retval)
 
 def load(filename):
@@ -104,7 +132,7 @@ class Segment(object):
     def pretty_string(self, stride=16):
         retval = []
         addresses = self.addresses
-        ranges = [addresses[i:i+stride] for i in range(0, self.size, stride)] 
+        ranges = [addresses[i:i+stride] for i in range(0, self.size, stride)]
         for r in ranges:
             retval.append('%08x ' % r[0] + ' '.join(['%02x' % self[addr] for addr in r]))
         return '\n'.join(retval)
@@ -137,7 +165,7 @@ class Segment(object):
             if not address in self:
                 raise IndexError("Address 0x%x is not in this segment" % address)
             return self.data[address-self.start_address]
-    
+
     @property
     def addresses(self):
         return range(self.start_address, self.end_address)


### PR DESCRIPTION
Added cases for record type 02 "Extended Segment Address", 03 "Start Segment Address" and 05 "Start Linear Address", based on docs in http://www.piclist.com/techref/fileext/hex/intel.htm and https://en.wikipedia.org/wiki/Intel_HEX. It's not super clear what it means when someone mixes 02 and 04 in the same hex file, but a few sources said they just add together.

Tested it out some hex images in https://github.com/adafruit/Adafruit_BluefruitLE_Firmware that were giving errors when I used this library.
